### PR TITLE
Clean up using directives

### DIFF
--- a/WordpressService.cs
+++ b/WordpressService.cs
@@ -1,39 +1,18 @@
-﻿using iText.Kernel.Pdf;
-using iText.Layout;
-using iText.Layout.Element;
-using System.IO;
-using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using System.Reflection.Metadata;
-using System.Text;
-using System.Text.Json;
-using System.Threading.Tasks;
-using Document = iText.Layout.Document;
-using static iText.Svg.SvgConstants;
-
-using iText.IO.Font.Constants;
-using iText.Kernel.Font;
-using iText.Kernel.Pdf;
-using iText.Layout;
-using iText.Layout.Element;
-using iText.IO.Font;
-using static System.Net.WebRequestMethods;
-
-using iText.IO.Font.Constants;
-using iText.Kernel.Font;
-using iText.Kernel.Pdf;
-using iText.Layout;
-using iText.Layout.Element;
-using System;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using iText.IO.Font.Constants;
+using iText.Kernel.Font;
+using iText.Kernel.Pdf;
+using iText.Layout;
+using iText.Layout.Element;
+using Document = iText.Layout.Document;
 
 namespace PublishBlogWordpress
 {


### PR DESCRIPTION
## Summary
- remove duplicate and unused using statements in `WordpressService.cs`
- keep only the namespaces required for compilation

## Testing
- `dotnet build PublishBlogWordpress.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6855710fdb30832fb40724e8913c5f01