### PR TITLE
Update posting interval and content prompts

### DIFF
--- a/ChatGptService.cs
+++ b/ChatGptService.cs
@@ -68,11 +68,11 @@ namespace PublishBlogWordpress
         public async Task<GeneratedPost> GeneratePostAsync(string topic)
         {
             var prompt = $@"
-Eres un experto redactor SEO. Para el tema ""{topic}"":
-1. Sugiéreme una categoría única.
-2. Dame 5 tags SEO.
-3. Crea un título llamativo de máximo 70 caracteres.
-4. Redacta un artículo de ~500 palabras en HTML.
+Eres un experto redactor SEO y de periodismo digital. Para el tema ""{topic}"":
+1. Sugiere la categoría más habitual en blogs que encaje con el tema (evita nombres extraños).
+2. Proporciona 5 tags optimizados para SEO.
+3. Escribe un título muy llamativo y sensacionalista al estilo clickbait, máximo 70 caracteres.
+4. Redacta un artículo de unas 500 palabras en español, con tono amigable y ofreciendo información relevante e interesante. Usa HTML sencillo.
 
 RESPONDE ÚNICAMENTE con un objeto JSON con estas llaves:
 {{

--- a/WordpressService.cs
+++ b/WordpressService.cs
@@ -73,6 +73,10 @@ namespace PublishBlogWordpress
             if (found != null)
                 return found.Id;
 
+            // Si hay resultados de búsqueda, reutiliza la primera categoría encontrada
+            if (list.Count > 0)
+                return list[0].Id;
+
             // 2) Crear la categoría si no existe
             var payload = new { name };
             var postReq = new HttpRequestMessage(HttpMethod.Post, "/wp-json/wp/v2/categories")

--- a/Worker.cs
+++ b/Worker.cs
@@ -18,8 +18,8 @@ namespace PublishBlogWordpress
 
         protected override async Task ExecuteAsync(CancellationToken ct)
         {
-            // Intervalo: cada 6 horas
-            var intervalo = TimeSpan.FromHours(6);
+            // Intervalo: cada 4 horas
+            var intervalo = TimeSpan.FromHours(4);
             while (!ct.IsCancellationRequested)
             {
                 try


### PR DESCRIPTION
## Summary
- reduce worker posting interval to every 4 hours
- generate more clickbait-friendly content in Spanish
- reuse existing categories when possible

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685575f3c77c832fa8a0a19bb66c8e35