### PR TITLE
Add image generation for posts

### DIFF
--- a/ImagenService.cs
+++ b/ImagenService.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Options;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace PublishBlogWordpress
+{
+    public class ImagenService
+    {
+        readonly HttpClient _openAI;
+        readonly HttpClient _wp;
+        readonly string _apiKey;
+
+        public ImagenService(IHttpClientFactory factory,
+            IOptions<OpenAISettings> openAiOpts,
+            IOptions<WordPressSettings> wpOpts)
+        {
+            _apiKey = openAiOpts.Value.ApiKey;
+
+            _openAI = factory.CreateClient();
+            _openAI.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", _apiKey);
+
+            var cfg = wpOpts.Value;
+            _wp = factory.CreateClient();
+            _wp.BaseAddress = new Uri(cfg.SiteUrl.TrimEnd('/'));
+            _wp.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (compatible; WPClient/1.0)");
+            var token = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{cfg.Username}:{cfg.AppPassword}"));
+            _wp.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", token);
+        }
+
+        public async Task<string> GenerateAndUploadAsync(string prompt, string filename)
+        {
+            var body = new
+            {
+                prompt = prompt,
+                n = 1,
+                size = "512x512"
+            };
+
+            var resp = await _openAI.PostAsJsonAsync("https://api.openai.com/v1/images/generations", body);
+            var json = await resp.Content.ReadAsStringAsync();
+
+            if (!resp.IsSuccessStatusCode)
+                throw new ApplicationException($"OpenAI image error {resp.StatusCode}: {json}");
+
+            using var doc = JsonDocument.Parse(json);
+            var url = doc.RootElement.GetProperty("data")[0].GetProperty("url").GetString();
+            if (string.IsNullOrEmpty(url))
+                throw new ApplicationException("OpenAI image URL missing");
+
+            var imageBytes = await _openAI.GetByteArrayAsync(url);
+
+            var uploadReq = new HttpRequestMessage(HttpMethod.Post, "/wp-json/wp/v2/media");
+            uploadReq.Content = new ByteArrayContent(imageBytes);
+            uploadReq.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+            uploadReq.Headers.Accept.Clear();
+            uploadReq.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
+            uploadReq.Headers.Add("Content-Disposition", $"attachment; filename=\"{filename}.png\"");
+
+            var uploadResp = await _wp.SendAsync(uploadReq);
+            var uploadBody = await uploadResp.Content.ReadAsStringAsync();
+            if (!uploadResp.IsSuccessStatusCode)
+                throw new ApplicationException($"Error subiendo imagen: {uploadResp.StatusCode} {uploadBody}");
+
+            using var docUpload = JsonDocument.Parse(uploadBody);
+            return docUpload.RootElement.GetProperty("source_url").GetString()!;
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -10,6 +10,7 @@ IHost host = Host.CreateDefaultBuilder(args)
 
         services.AddHttpClient(); // para llamar API de WP y OpenAI
         services.AddSingleton<ChatGptService>();
+        services.AddSingleton<ImagenService>();
         services.AddSingleton<WordPressService>();
         services.AddHostedService<TrendingPostWorker>();
     })

--- a/Worker.cs
+++ b/Worker.cs
@@ -4,15 +4,18 @@ namespace PublishBlogWordpress
     {
         readonly ChatGptService _chat;
         readonly WordPressService _wp;
+        readonly ImagenService _img;
         readonly ILogger<TrendingPostWorker> _log;
 
         public TrendingPostWorker(
             ChatGptService chat,
             WordPressService wp,
+            ImagenService img,
             ILogger<TrendingPostWorker> log)
         {
             _chat = chat;
             _wp = wp;
+            _img = img;
             _log = log;
         }
 
@@ -30,6 +33,9 @@ namespace PublishBlogWordpress
                     {
                         _log.LogInformation("Generando post para tema: {Tema}", t);
                         var gp = await _chat.GeneratePostAsync(t);
+                        var slug = gp.Title.ToLowerInvariant().Replace(" ", "-");
+                        var imgUrl = await _img.GenerateAndUploadAsync(gp.Title, slug);
+                        gp.Content = $"<img src='{imgUrl}' alt='{gp.Title}' />\n" + gp.Content;
                         await _wp.CreatePostAsync(gp);
                         _log.LogInformation("Publicado: {Title}", gp.Title);
                         // Pequena pausa entre posts


### PR DESCRIPTION
## Summary
- generate OpenAI images and upload them to WordPress
- register `ImagenService` and inject it into the worker
- prepend generated image to post content before publishing

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855773f0b0c832f9f28c40417b88594