### PR TITLE
Fix options and cleanup

### DIFF
--- a/ChatGptService.cs
+++ b/ChatGptService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;

--- a/ImagenService.cs
+++ b/ImagenService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Org.BouncyCastle.Asn1.Ocsp;
 using Org.BouncyCastle.Utilities;
 using System;

--- a/PdfService.cs
+++ b/PdfService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,12 +7,10 @@ using iText.Kernel.Pdf;
 using iText.Layout;
 using iText.Layout.Element;
 using Microsoft.Extensions.Options;
-using System;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
-using System.Threading.Tasks;
 
 
 namespace PublishBlogWordpress

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,7 @@
 using PublishBlogWordpress;
 using PdfTutorialsFree.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((ctx, services) =>
@@ -9,7 +11,6 @@ IHost host = Host.CreateDefaultBuilder(args)
         services.Configure<OpenAISettings>(ctx.Configuration.GetSection("OpenAI"));
         services.Configure<WordPressSettings>(ctx.Configuration.GetSection("WordPress"));
 
-        services.AddHttpClient(); // para llamar API de WP y OpenAI
         services.AddWordPressMedia(
             openAI => openAI.ApiKey = ctx.Configuration["OpenAI:ApiKey"] ?? string.Empty,
             wordpress =>

--- a/PublishBlogWordpress.csproj
+++ b/PublishBlogWordpress.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
+<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>

--- a/PublishBlogWordpress.sln
+++ b/PublishBlogWordpress.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.13.35825.156 d17.13

--- a/WordPressMediaService.cs
+++ b/WordPressMediaService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -9,8 +9,18 @@ using Microsoft.Extensions.Options;
 
 namespace PdfTutorialsFree.Services
 {
-    public record OpenAIOptions(string ApiKey, string Endpoint = "https://api.openai.com/v1/images/generations");
-    public record WordPressOptions(string BaseUrl, string Username, string AppPassword);
+    public class OpenAIOptions
+    {
+        public string ApiKey { get; set; } = string.Empty;
+        public string Endpoint { get; set; } = "https://api.openai.com/v1/images/generations";
+    }
+
+    public class WordPressOptions
+    {
+        public string BaseUrl { get; set; } = string.Empty;
+        public string Username { get; set; } = string.Empty;
+        public string AppPassword { get; set; } = string.Empty;
+    }
 
     public interface IWordPressMediaService
     {


### PR DESCRIPTION
## Summary
- define `OpenAIOptions` and `WordPressOptions` as mutable classes
- strip UTF‑8 BOM markers from several files
- include explicit host/usings and remove redundant `AddHttpClient` call

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559957a3d4832f9d2dfec73b511c63